### PR TITLE
Basic stubbing for the C++ project codebase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ This project moves very slowly because I have very little time to work on it.
 Here are a couple implementations which are roughly equivalent in terms of the outer API and inner numerical properties, but computational performance may differ. 
 
 * The [C# codebase](src/csharp/readme.md) is usable.
-* The [C++ codebase](src/cpp/readme.md) will be started next.
+* The [C++ codebase](src/cpp/readme.md) is just getting started.
 
 ### The original project is unsupported
 This was the code I had when MoRPE was first invented.

--- a/src/cpp/.editorconfig
+++ b/src/cpp/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+tab_width = 4
+max_line_length = 160

--- a/src/cpp/.gitignore
+++ b/src/cpp/.gitignore
@@ -1,0 +1,8 @@
+# Build output folders
+cmake-build-*/
+
+# Files dropped by `conan install ...` commands
+conanbuildinfo.txt
+conaninfo.txt
+graph_info.json
+

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.24)
+project(morpe_cpp CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+# Set the default build type
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)  # Possible values are:  Debug, Release, RelWithDebInfo and MinSizeRel
+endif()
+
+# Compiler flags
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # using Clang
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -Wno-unknown-pragmas -Wno-unused-label -Wno-attributes")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-unknown-pragmas -Wno-unused-label -Wno-attributes")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # using GCC
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -Wno-unknown-pragmas -Wno-unused-label -Wno-attributes")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-unknown-pragmas -Wno-unused-label -Wno-attributes")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    # using Intel C++
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # using Visual Studio C++
+endif()
+
+# Remove 'lib' prefix for Windows libraries
+if (WIN32)
+    # This affects the names of the libraries that are being pulled in (as dependencies).
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif ()
+
+# Sub-projects:  The order matters.
+add_subdirectory(morpe)
+add_subdirectory(tests)

--- a/src/cpp/build.ps1
+++ b/src/cpp/build.ps1
@@ -1,0 +1,43 @@
+# The Windows Build:  Execute this from a prompt of type `Developer PowerShell for VS 2022`.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$conan_profile = "$PSScriptRoot/conan/profiles/win64"
+
+$build_types = @("Debug", "RelWithDebInfo")
+$subprojects = @("morpe", "tests/morpe")
+
+foreach ($build_type in $build_types)
+{
+    $build_folder = "$PSScriptRoot/cmake-build-$($build_type.ToLower() )"
+
+    foreach ($subproject in $subprojects)
+    {
+        $proj_folder = "$PSScriptRoot/$subproject"
+        $proj_build_folder = "$build_folder/$subproject"
+
+        Write-Host "[BEGIN] $build_type $subproject conan install"
+
+        mkdir -Force "$proj_build_folder"
+        conan install "$proj_folder" --install-folder "$proj_build_folder" --build=outdated --update --profile $conan_profile -s build_type=$build_type
+
+        Write-Host "[END] $build_type $subproject conan install"
+    }
+
+    # ------------------------------------------------------------
+
+    Write-Host "[BEGIN] $build_type configure"
+
+    cmake -DCMAKE_BUILD_TYPE=$build_type -S "$PSScriptRoot" -B "$build_folder"
+
+    Write-Host "[END] $build_type configure"
+
+    # ------------------------------------------------------------
+
+    Write-Host "[BEGIN] $build_type build"
+
+    make --directory="$build_folder"
+
+    Write-Host "[END] $build_type build"
+}

--- a/src/cpp/conan/profiles/win64
+++ b/src/cpp/conan/profiles/win64
@@ -1,0 +1,16 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=17
+build_type=Debug
+cppstd=20
+
+[options]
+
+[build_requires]
+
+[env]
+

--- a/src/cpp/morpe/CMakeLists.txt
+++ b/src/cpp/morpe/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.24)
+project(morpe CXX)
+
+# Pull stuff from conan
+include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+
+# This allows boost::stacktrace to show filenames with line numbers.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D BOOST_STACKTRACE_LINK")
+
+# Basic setup of conan.
+conan_basic_setup()
+
+# Get all the *.cpp files
+file(GLOB_RECURSE sourceFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.cpp")
+
+add_library(morpe STATIC ${sourceFiles} src/morpe.cpp include/morpe.h)
+
+# The -fPIC compiler option (gcc), requried for building libraries on linux and unix.
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+
+# Set the include directories
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CONAN_INCLUDE_DIRS})
+
+# Link to various libraries.
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+# Export the project properties (including transitive dependencies) to other projects
+set(${PROJECT_NAME}_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
+        CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)

--- a/src/cpp/morpe/conanfile.txt
+++ b/src/cpp/morpe/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+boost/1.81.0
+eigen/3.4.0
+
+[generators]
+cmake
+
+[options]
+boost:shared=False

--- a/src/cpp/morpe/include/morpe.h
+++ b/src/cpp/morpe/include/morpe.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "morpe/_internal.h"
+#include "morpe/sal.h"

--- a/src/cpp/morpe/include/morpe/_internal.h
+++ b/src/cpp/morpe/include/morpe/_internal.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// This header file is special:  It gets pulled early into almost every other header file in this project.
+
+//  Helper functions for macros
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+//  This is used for logging and debugging.  Shows filename and line.  Can be passed to a function as string.
+#define THIS_LINE __FILE__ ":" TOSTRING(__LINE__)
+
+//  Shared library export and import annotations.  For example, when consuming a DLL:
+//
+//    #include "morpe/_first_header_file.h"
+//    #define MORPE_API MORPE_IMPORT
+//    #include "morpe.h"
+#if defined _WIN32 || defined _WIN64 || defined __CYGWIN__ || defined __clang__
+    #ifdef __GNUC__
+        #define MORPE_IMPORT __attribute__((dllimport))
+        #define MORPE_EXPORT __attribute__((dllexport))
+    #else
+        #define MORPE_IMPORT __declspec(dllimport)
+        #define MORPE_EXPORT __declspec(dllexport)
+    #endif
+    #define MORPE_HIDE
+#else
+    #define MORPE_EXPORT __attribute__((visibility ("default")))
+    #define MORPE_IMPORT MORPE_EXPORT
+    #define MORPE_HIDE   __attribute__((visibility ("hidden")))
+#endif
+
+// By default, the header files are used to build the shared library (not consume it).
+#define MORPE_API MORPE_EXPORT

--- a/src/cpp/morpe/include/morpe/mingw64/sal.h
+++ b/src/cpp/morpe/include/morpe/mingw64/sal.h
@@ -1,0 +1,205 @@
+// This file is a (slightly) modified version of a file taken from the mingw-w64 runtime package.
+//
+// This file has no copyright assigned and is placed in the Public Domain.  No warranty is given.
+
+#pragma once
+
+#ifdef __GNUC__
+#  define __inner_checkReturn __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#  define __inner_checkReturn __declspec("SAL_checkReturn")
+#else
+#  define __inner_checkReturn
+#endif
+
+#define __checkReturn __inner_checkReturn
+
+/* Pointer parameters */
+#define _In_
+#define _Out_
+#define _Inout_
+#define _In_z_
+#define _Inout_z_
+#define _In_reads_(s)
+#define _In_reads_bytes_(s)
+#define _In_reads_z_(s)
+#define _In_reads_or_z_(s)
+#define _Out_writes_(s)
+#define _Out_writes_bytes_(s)
+#define _Out_writes_z_(s)
+#define _Inout_updates_(s)
+#define _Inout_updates_bytes_(s)
+#define _Inout_updates_z_(s)
+#define _Out_writes_to_(s,c)
+#define _Out_writes_bytes_to_(s, c)
+#define _Out_writes_all_(s)
+#define _Out_writes_bytes_all_(s)
+#define _Inout_updates_to_(s, c)
+#define _Inout_updates_bytes_to_(s, c)
+#define _Inout_updates_all_(s)
+#define _Inout_updates_bytes_all_(s)
+#define _In_reads_to_ptr_(p)
+#define _In_reads_to_ptr_z_(p)
+#define _Out_writes_to_ptr_(p)
+#define _Out_writes_to_ptr_z(p)
+
+/* Optional pointer parameters */
+#define _In_opt_
+#define _Out_opt_
+#define _Inout_opt_
+#define _In_opt_z_
+#define _Inout_opt_z_
+#define _In_reads_opt_(s)
+#define _In_reads_bytes_opt_(s)
+#define _In_reads_opt_z_(s)
+
+#define _Out_writes_opt_(s)
+#define _Out_writes_opt_z_(s)
+#define _Inout_updates_opt_(s)
+#define _Inout_updates_bytes_opt_(s)
+#define _Inout_updates_opt_z_(s)
+#define _Out_writes_to_opt_(s, c)
+#define _Out_writes_bytes_to_opt_(s, c)
+#define _Out_writes_all_opt_(s)
+#define _Out_writes_bytes_all_opt_(s)
+
+#define _Inout_updates_to_opt_(s, c)
+#define _Inout_updates_bytes_to_opt_(s, c)
+#define _Inout_updates_all_opt_(s)
+#define _Inout_updates_bytes_all_opt_(s)
+#define _In_reads_to_ptr_opt_(p)
+#define _In_reads_to_ptr_opt_z_(p)
+#define _Out_writes_to_ptr_opt_(p)
+#define _Out_writes_to_ptr_opt_z_(p)
+
+/* Output pointer parameters */
+#define _Outptr_
+#define _Outptr_opt_
+#define _Outptr_result_maybenull_
+#define _Outptr_opt_result_maybenull_
+#define _Outptr_result_z_
+#define _Outptr_opt_result_z_
+#define _Outptr_result_maybenull_z_
+#define _Outptr_opt_result_maybenull_z_
+#define _COM_Outptr_
+#define _COM_Outptr_opt_
+#define _COM_Outptr_result_maybenull_
+#define _COM_Outptr_opt_result_maybenull_
+#define _Outptr_result_buffer_(s)
+#define _Outptr_result_bytebuffer_(s)
+#define _Outptr_opt_result_buffer_(s)
+#define _Outptr_opt_result_bytebuffer_(s)
+#define _Outptr_result_buffer_to_(s, c)
+#define _Outptr_result_bytebuffer_to_(s, c)
+#define _Outptr_result_bytebuffer_maybenull_(s)
+#define _Outptr_opt_result_buffer_to_(s, c)
+#define _Outptr_opt_result_bytebuffer_to_(s, c)
+#define _Result_nullonfailure_
+#define _Result_zeroonfailure_
+#define _Outptr_result_nullonfailure_
+#define _Outptr_opt_result_nullonfailure_
+#define _Outref_result_nullonfailure_
+
+/* Output reference parameters */
+#define _Outref_
+#define _Outref_result_maybenull_
+#define _Outref_result_buffer_(s)
+#define _Outref_result_bytebuffer_(s)
+#define _Outref_result_buffer_to_(s, c)
+#define _Outref_result_bytebuffer_to_(s, c)
+#define _Outref_result_buffer_all_(s)
+#define _Outref_result_bytebuffer_all_(s)
+#define _Outref_result_buffer_maybenull_(s)
+#define _Outref_result_bytebuffer_maybenull_(s)
+#define _Outref_result_buffer_to_maybenull_(s, c)
+#define _Outref_result_bytebuffer_to_maybenull_(s, c)
+#define _Outref_result_buffer_all_maybenull_(s)
+#define _Outref_result_bytebuffer_all_maybenull_(s)
+
+/* Return values */
+#define _Ret_z_
+#define _Ret_writes_(s)
+#define _Ret_writes_bytes_(s)
+#define _Ret_writes_z_(s)
+#define _Ret_writes_bytes_to_(s, c)
+#define _Ret_writes_maybenull_(s)
+#define _Ret_writes_to_maybenull_(s, c)
+#define _Ret_writes_maybenull_z_(s)
+#define _Ret_maybenull_
+#define _Ret_maybenull_z_
+#define _Ret_null_
+#define _Ret_notnull_
+#define _Ret_writes_bytes_to_(s, c)
+#define _Ret_writes_bytes_maybenull_(s)
+#define _Ret_writes_bytes_to_maybenull_(s, c)
+
+/* Other common annotations */
+#define _In_range_(low, hi)
+#define _Out_range_(low, hi)
+#define _Ret_range_(low, hi)
+#define _Deref_in_range_(low, hi)
+#define _Deref_out_range_(low, hi)
+#define _Deref_inout_range_(low, hi)
+#define _Pre_equal_to_(expr)
+#define _Post_equal_to_(expr)
+#define _Struct_size_bytes_(size)
+
+/* Function annotations */
+#define _Called_from_function_class_(name)
+#define _Check_return_ __checkReturn
+#define _Function_class_(name)
+#define _Raises_SEH_exception_
+#define _Maybe_raises_SEH_exception_
+#define _Must_inspect_result_
+#define _Use_decl_annotations_
+
+/* Success/failure annotations */
+#define _Always_(anno_list)
+#define _On_failure_(anno_list)
+#define _Return_type_success_(expr)
+#define _Success_(expr)
+
+#define _Reserved_
+#define _Const_
+
+/* Buffer properties */
+#define _Readable_bytes_(s)
+#define _Readable_elements_(s)
+#define _Writable_bytes_(s)
+#define _Writable_elements_(s)
+#define _Null_terminated_
+#define _NullNull_terminated_
+#define _Pre_readable_size_(s)
+#define _Pre_writable_size_(s)
+#define _Pre_readable_byte_size_(s)
+#define _Pre_writable_byte_size_(s)
+#define _Post_readable_size_(s)
+#define _Post_writable_size_(s)
+#define _Post_readable_byte_size_(s)
+#define _Post_writable_byte_size_(s)
+
+/* Field properties */
+#define _Field_size_(s)
+#define _Field_size_full_(s)
+#define _Field_size_full_opt_(s)
+#define _Field_size_opt_(s)
+#define _Field_size_part_(s, c)
+#define _Field_size_part_opt_(s, c)
+#define _Field_size_bytes_(size)
+#define _Field_size_bytes_full_(size)
+#define _Field_size_bytes_full_opt_(s)
+#define _Field_size_bytes_opt_(s)
+#define _Field_size_bytes_part_(s, c)
+#define _Field_size_bytes_part_opt_(s, c)
+#define _Field_z_
+#define _Field_range_(min, max)
+
+/* Structural annotations */
+#define _At_(e, a)
+#define _At_buffer_(e, i, c, a)
+#define _Group_(a)
+#define _When_(e, a)
+
+/* Analysis */
+#define _Analysis_assume_(expr)
+#define _Analysis_assume_nullterminated_(expr)

--- a/src/cpp/morpe/include/morpe/sal.h
+++ b/src/cpp/morpe/include/morpe/sal.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "_internal.h"
+
+#if defined_WIN32 || defined _WIN64
+#   include <sal.h>          // from windows
+#else
+#   include "mingw64/sal.h"  // from mingw64
+#endif

--- a/src/cpp/morpe/src/morpe.cpp
+++ b/src/cpp/morpe/src/morpe.cpp
@@ -1,0 +1,2 @@
+#include "morpe.h"
+

--- a/src/cpp/readme.md
+++ b/src/cpp/readme.md
@@ -1,7 +1,41 @@
 # c++
+This is a C++ project using CMake and Conan.
 
 ## status
-This version will be started next.
+This is just getting started.
 
 ## summary
 This is a modern implementation of MoRPE.  The intent is to match the API and numerical functionality of the C# version.
+
+## setup and build
+
+### windows
+
+#### setup
+Install VS 2022 (not free) or Build Tools for VS 2022 (free).
+  * TO DO:  Do they need to check boxes for C++ support?
+  * TO DO:  Do they need to install a particular Windows SDK?
+
+Install conan, cmake.
+
+```pwsh
+# Elevated prompt
+choco install --yes conan
+choco install --yes cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+choco install --yes make
+```
+
+#### build
+From a prompt of type `Developer PowerShell for VS 2022`:
+
+```pwsh
+./build.ps1
+```
+
+### linux (fedora 34)
+
+#### setup
+TO DO
+
+#### build
+TO DO

--- a/src/cpp/tests/CMakeLists.txt
+++ b/src/cpp/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.24)
+project(tests)
+
+# Sub-projects:  The order matters.
+add_subdirectory(morpe)

--- a/src/cpp/tests/morpe/CMakeLists.txt
+++ b/src/cpp/tests/morpe/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.24)
+project(tests_morpe)
+
+# Pull stuff from conan
+include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+# Get all the *.cpp files
+file(GLOB_RECURSE sourceFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.cpp")
+
+# Define the output type of executable.
+add_executable(${PROJECT_NAME} ${sourceFiles})
+
+# Set the include directories
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CONAN_INCLUDE_DIRS})
+
+# Link to various libraries.
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${morpe_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} morpe)

--- a/src/cpp/tests/morpe/conanfile.txt
+++ b/src/cpp/tests/morpe/conanfile.txt
@@ -1,0 +1,11 @@
+[requires]
+boost/1.81.0
+eigen/3.4.0
+gtest/1.12.1
+
+[generators]
+cmake
+
+[options]
+boost:shared=False
+gtest:shared=False

--- a/src/cpp/tests/morpe/include/main.h
+++ b/src/cpp/tests/morpe/include/main.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "morpe.h"

--- a/src/cpp/tests/morpe/src/main.cpp
+++ b/src/cpp/tests/morpe/src/main.cpp
@@ -1,0 +1,6 @@
+#include "main.h"
+
+int main(int nargs, char** args)
+{
+    return 0;
+}

--- a/src/csharp/.editorconfig
+++ b/src/csharp/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset = utf-8
-end_of_line = crlf
-trim_trailing_whitespace = false
+end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/src/csharp/Morpe/TrainingContext.cs
+++ b/src/csharp/Morpe/TrainingContext.cs
@@ -68,7 +68,6 @@ namespace Morpe
             [NotNull] TrainingOptions options)
         {
         }
-
         
         /// <summary>
         /// The classifiers that have been trained up to this point.


### PR DESCRIPTION
There was no real code added here, just basic stubbing.

Summary of changes:
* Basic project stubbing for the C++ codebase
* CMake
* Conan
* Basic install script for windows (build.ps1), we can do Linux later.
* `morpe` static library project
  * We can think about producing a shared library later, though I'm not sure what kind of API would make sense.
* `tests/morpe` executable GTest project
  * For all the unit testing
* SAL annotations (even on linux)
* I am not sure if my CLion IDE will recognize the `.editorconfig` file.