### PR TITLE
Move function comments from cpp files to h files

### DIFF
--- a/src/cpp/morpe/include/morpe/err.h
+++ b/src/cpp/morpe/include/morpe/err.h
@@ -41,6 +41,7 @@ namespace morpe { namespace err
     };
 
     /// Throws a #stop_error if a stop was requested.
+    /// @param stop_token The token which can be used to determine if a stop was requested.
     void throw_if_stopped(
             _In_ std::stop_token stop_token);
 

--- a/src/cpp/morpe/include/morpe/numerics/D1/monotonic_regressor.h
+++ b/src/cpp/morpe/include/morpe/numerics/D1/monotonic_regressor.h
@@ -16,6 +16,17 @@ namespace morpe { namespace numerics { namespace D1
     class monotonic_regressor
     {
     public:
+        /// Performs a monotonic regression of a tabulated function.  This method calculates a monotonic function that is approximately equal
+        /// to the tabulated function provided.
+        /// @param stop_token If triggered, a #stop_error will be thrown quickly.
+        /// @param type The type of monotonic regression.
+        /// @param input The tabulated function.
+        /// @param output The monotonic function.  This should be supplied as a vector of length identical to input.
+        /// The following will be guaranteed:
+        ///     mean(output) == mean(input)
+        ///     min(output)  >= min(input)
+        ///     max(output)  <= max(input)
+        /// @return The number of trips through an inner loop.
         int32_t run(
                 _In_    std::stop_token stop_token,
                 _In_    monotonic_regression_type type,
@@ -34,6 +45,21 @@ namespace morpe { namespace numerics { namespace D1
         /// Intermediate storage for an intermediate result:  The non-decreasing function.
         std::vector<double> non_decreasing_values;
 
+        /// Repeatedly spread decreasing energy to immediate neighbors until a threshold is met, or until we have gone through the
+        /// loop too many times.  Decreasing energy is annihilated by increasing energy.  Thus, it tends to be annihilated by this
+        /// spreading action.
+        ///
+        /// This is the best approach to annihilating the decreasing energy, but this method may not eliminate all of it.  Even so,
+        /// it typically gets us most of the way home.
+        /// @param stop_token If triggered, a #stop_error will be thrown quickly.
+        /// @param dy_min The minimum value of 'dy'.  This value will be updated with each trip through the loop.
+        /// @param dy_min_threshold The loop may exit when 'dy_min' exceeds this value.  This should be a small negative number.
+        /// @param limit_num_trips_through_loop The maximum number of trips through the loop.
+        /// @param y The tabulated values of the function 'y'.
+        /// @param dy The diff of 'y' values.  For all y:  dy[i] = y[i+1] - y[i].
+        ///     This vector may have extra length allocated (just for efficient heap utilization).  The extra elements
+        ///     can be ignored.
+        /// @return The number of trips taken through the loop.
         static int32_t annihilate_decreasing_energy(
                 _In_    std::stop_token stop_token,
                 _Inout_ double& dy_min,
@@ -42,10 +68,31 @@ namespace morpe { namespace numerics { namespace D1
                 _Inout_ std::vector<double>& y,
                 _Inout_ std::vector<double>& dy);
 
+        /// This is needed in the context of calculating a #monotonic_regression_type::blended monotonic regression,
+        /// an operation basically blends the outputs of the other operation types.
+        /// * #monotonic_regression_type::non_decreasing
+        /// * #monotonic_regression_type::increasing
+        ///
+        /// This method calculates a "blend factor", or basically a weighting used to mix the two other output types.
+        /// @param non_decreasing_values The monotonic regression output for #monotonic_regression_type::non_decreasing.
+        /// @param length The actual number of non-decreasing values, since the vector passed in may have extra padding.
+        /// @return The proportion of weight given to the #monotonic_regression_type::increasing values.
         static double calculate_blend_factor(
                 _In_    const std::vector<double>& non_decreasing_values,
                 _In_    int32_t length);
 
+        /// Modifies the non-decreasing values of 'y' to be strictly increasing, so that each value of 'y' is greater than (not equal to) the prior value.
+        /// @param y The tabulated values of the function 'y'.  On input, we know that these values are non-decreasing, but not necessarily
+        ///     increasing.  On output, these values will be modified and will contain the increasing values.
+        /// @param dy The diff of 'y' values.  For all y:  dy[i] = y[i+1] - y[i].  These values will be modified.
+        ///     This vector may have extra length allocated (just for efficient heap utilization).  The extra elements
+        ///     can be ignored.
+        ///
+        ///     On exit, these values will be meaningless:  They are not kept in sync with 'y'.
+        /// @param ymean The mean of 'y'.  Although we will change the 'y' values, we will ensure that it still has this mean.
+        /// @param ymin The minimum allowed value of 'y'.  No value of 'y' will be below this minimum.
+        /// @param ymax The maximum allowed value of 'y'.  No value of 'y' will be above this maximum.
+        /// @param dymin The current minimum value of the 'dy' vector.
         static void convert_non_decreasing_to_increasing(
                 _Inout_ std::vector<double>& y,
                 _Inout_ std::vector<double>& dy,
@@ -54,6 +101,20 @@ namespace morpe { namespace numerics { namespace D1
                 _In_    double ymax,
                 _In_    double dymin);
 
+        /// This is executed after <see cref="AnnihilateDecreasingEnergy"/> to ensure that all decreasing energy has been finally eliminated.  This method is
+        /// not the best way to annihilate the decreasing energy, but it does guarantee the following:
+        /// * 'y' will be non-decreasing.
+        /// * 'dy' will be non-negative.
+        /// * The mean of 'y' will be 'yMean'.
+        /// * The min of 'y' shall not be below 'yMin'.
+        /// * The max of 'y' shall not be above 'yMax'.
+        /// @param y The tabulated values of the function 'y'.
+        /// @param dy The diff of 'y' values.  For all y:  dy[i] = y[i+1] - y[i].
+        ///     This vector may have extra length allocated (just for efficient heap utilization).  The extra elements
+        ///     can be ignored.
+        /// @param ymean The mean of 'y'.  Although we will change the 'y' values, we will ensure that it still has this mean.
+        /// @param ymin The minimum allowed value of 'y'.  No value of 'y' will be below this minimum.
+        /// @param ymax The maximum allowed value of 'y'.  No value of 'y' will be above this maximum.
         static void eliminate_decreasing_energy(
                 _Inout_ std::vector<double>& y,
                 _Inout_ std::vector<double>& dy,
@@ -61,11 +122,26 @@ namespace morpe { namespace numerics { namespace D1
                 _In_    double ymin,
                 _In_    double ymax);
 
+        /// If decreasing energy is present at the given index, then it is moved to the adjacent indices (idx-1, idx+1).
+        /// If either of the adjacent indices has increasing energy, it will annihilate the decreasing energy in equal
+        /// measure.
+        ///
+        /// @idx The zero-based index into 'y' where the adjustment is to be made.
+        /// @param y The tabulated values of the function 'y'.
+        /// @param dy The diff of 'y' values.  For all y:  dy[i] = y[i+1] - y[i].
+        ///     This vector may have extra length allocated (just for efficient heap utilization).  The extra elements
+        ///     can be ignored.
         static void repel_decreasing_energy_from_index(
                 _In_    int32_t idx,
                 _Inout_ std::vector<double>& y,
                 _Inout_ std::vector<double>& dy);
 
+        /// Updates the values of 'dy' given the current values of 'y' and also finds the minimum of 'dy'.
+        /// @param y The current values of 'y'.
+        /// @param dy A container which holds the output values of 'dy'.
+        ///     This vector may have extra length allocated (just for efficient heap utilization).  The extra elements
+        ///     can be ignored.
+        /// @return The minimum value of 'dy'.
         static double update_derivative_and_find_min(
                 _In_    std::vector<double>& y,
                 _Inout_ std::vector<double>& dy);

--- a/src/cpp/morpe/include/morpe/numerics/I2.h
+++ b/src/cpp/morpe/include/morpe/numerics/I2.h
@@ -6,5 +6,9 @@
 
 namespace morpe { namespace numerics { namespace I2
 {
+    /// Returns the entry (a,b) of the Pascal matrix.  The parameters are interchangeable because the matrix is symmetric.
+    /// The value returned is equal to:  (a+b)! / a! / b!
+    /// @param a The row of the Pascal matrix.
+    /// @param b The column of the Pascal matrix.
     int pascal(int a, int b);
 }}}

--- a/src/cpp/morpe/include/morpe/polynomial.h
+++ b/src/cpp/morpe/include/morpe/polynomial.h
@@ -11,9 +11,9 @@ namespace morpe
     class polynomial
     {
     public:
-        //-------------------
+        //---------------------------------------
         // Member fields
-        //-------------------
+        //---------------------------------------
 
         /// The inhomogeneous polynomial coefficients.  Each row is non-decreasing and defines a coefficient.
         ///
@@ -50,30 +50,55 @@ namespace morpe
         ///   * ... and so on
         int32_t rank;
 
-        //-------------------
+        //---------------------------------------
         // Member functions
-        //-------------------
+        //---------------------------------------
 
+        /// Constructs the coefficients for a multivariate polynomial having the given rank and spatial dimensionality.
+        /// @param num_dims The number of spatial dimensions, see #num_dims.
+        /// @param rank The rank of the polynomial, see #rank.
         polynomial(int32_t num_dims, int32_t rank);
 
+        /// Computes 'output' as the polynomial expansion of 'input'.
+        /// @input  The feature vector (not expanded).
+        /// @return The expanded feature vector.
         Eigen::ArrayXf expand(
                 _In_ Eigen::VectorXf& input);
 
+        /// Computes 'output' as the polynomial expansion of 'input'.
+        /// @input  The feature vector (not expanded).
+        /// @output The expanded feature vector, pre-allocated to be the correct length.
         void expand(
                 _In_    Eigen::VectorXf& input,
                 _Inout_ Eigen::VectorXf& output);
 
-        //-------------------
+        //---------------------------------------
         // Static functions
-        //-------------------
+        //---------------------------------------
 
+        /// Computes a mapping from the subspace polynomial coefficients to the fullspace coefficients.
+        /// @param fullpoly The fullspace polynomial
+        /// @param subpoly  The subspace polynomial
+        /// @param subdims  For each spatial dimension of the subspace polynomial, this gives the index of the
+        /// corresponding spatial dimension in the fullspace polynomial.
+        /// @return For each coefficient of the subspace polynomial, this gives the corresponding index of the coefficient
+        /// in the fullspace polynomial.
         static std::vector<int32_t> map_subspace_to_fullspace(
                 _In_ polynomial& fullPoly,
                 _In_ polynomial& subPoly,
                 _In_ std::vector<int32_t> subdims);
 
+        /// Returns the number of inhomogeneous polynomial coefficients for a given dimensionality and rank, including
+        /// all coefficients of lesser rank.  However, it does not include the 0-th order term which MoRPE does not use.
+        /// @param num_dims #num_dims  The spatial dimensionality.
+        /// @param rank     #rank      The rank.
         static int32_t num_coeffs(int32_t num_dims, int32_t rank);
 
+        /// Returns the number of homogeneous polynomial coefficients for a given dimensionality and rank.
+        ///
+        /// This does NOT including coefficients of lesser rank (as per the term "homogeneous").
+        /// @param num_dims #num_dims  The spatial dimensionality.
+        /// @param rank     #rank      The rank.
         static int32_t num_coeffs_homo(int32_t num_dims, int32_t rank);
     };
 }

--- a/src/cpp/morpe/src/morpe/err.cpp
+++ b/src/cpp/morpe/src/morpe/err.cpp
@@ -2,7 +2,6 @@
 
 namespace morpe { namespace err
 {
-    /// Throws a #stop_error if a stop was requested.
     void throw_if_stopped(
             std::stop_token stop_token)
     {

--- a/src/cpp/morpe/src/morpe/numerics/I2.cpp
+++ b/src/cpp/morpe/src/morpe/numerics/I2.cpp
@@ -2,10 +2,6 @@
 
 namespace morpe { namespace numerics { namespace I2
 {
-    /// Returns the entry (a,b) of the Pascal matrix.  The parameters are interchangeable because the matrix is symmetric.
-    /// The value returned is equal to:  (a+b)! / a! / b!
-    /// @param a The row of the Pascal matrix.
-    /// @param b The column of the Pascal matrix.
     int pascal(int a, int b)
     {
         int32_t aa = std::max(a, b);

--- a/src/cpp/morpe/src/morpe/polynomial.cpp
+++ b/src/cpp/morpe/src/morpe/polynomial.cpp
@@ -7,9 +7,10 @@ using namespace morpe::numerics;
 
 namespace morpe
 {
-    /// Constructs the coefficients for a multivariate polynomial having the given rank and spatial dimensionality.
-    /// @param num_dims The number of spatial dimensions, see #num_dims.
-    /// @param rank The rank of the polynomial, see #rank.
+    //---------------------------------------
+    // constructors
+    //---------------------------------------
+
     polynomial::polynomial(int32_t num_dims, int32_t rank)
     {
         ThrowIf(num_dims < 1);
@@ -72,9 +73,10 @@ namespace morpe
         }
     }
 
-    /// Computes 'output' as the polynomial expansion of 'input'.
-    /// @input  The feature vector (not expanded).
-    /// @return The expanded feature vector.
+    //---------------------------------------
+    // public member functions
+    //---------------------------------------
+
     Eigen::ArrayXf polynomial::expand(
             _In_ Eigen::VectorXf &input)
     {
@@ -85,9 +87,6 @@ namespace morpe
     }
 
 
-    /// Computes 'output' as the polynomial expansion of 'input'.
-    /// @input  The feature vector (not expanded).
-    /// @output The expanded feature vector, pre-allocated to be the correct length.
     void polynomial::expand(
             _In_    Eigen::VectorXf& input,
             _Inout_ Eigen::VectorXf& output)
@@ -112,14 +111,10 @@ namespace morpe
         }
     }
 
-    /// STATIC
-    /// Computes a mapping from the subspace polynomial coefficients to the fullspace coefficients.
-    /// @param fullpoly The fullspace polynomial
-    /// @param subpoly  The subspace polynomial
-    /// @param subdims  For each spatial dimension of the subspace polynomial, this gives the index of the
-    /// corresponding spatial dimension in the fullspace polynomial.
-    /// @return For each coefficient of the subspace polynomial, this gives the corresponding index of the coefficient
-    /// in the fullspace polynomial.
+    //---------------------------------------
+    // public static functions
+    //---------------------------------------
+
     std::vector<int32_t> polynomial::map_subspace_to_fullspace(
             _In_ polynomial &fullpoly,
             _In_ polynomial &subpoly,
@@ -158,11 +153,6 @@ namespace morpe
         return output;
     }
 
-    /// STATIC
-    /// Returns the number of inhomogeneous polynomial coefficients for a given dimensionality and rank, including
-    /// all coefficients of lesser rank.  However, it does not include the 0-th order term which MoRPE does not use.
-    /// @param num_dims #num_dims  The spatial dimensionality.
-    /// @param rank     #rank      The rank.
     int32_t polynomial::num_coeffs(int32_t num_dims, int32_t rank)
     {
         // This is the number of coefficients including the 0-th order term.
@@ -183,12 +173,6 @@ namespace morpe
         return output;
     }
 
-    /// STATIC
-    /// Returns the number of homogeneous polynomial coefficients for a given dimensionality and rank.
-    ///
-    /// This does NOT including coefficients of lesser rank (as per the term "homogeneous").
-    /// @param num_dims #num_dims  The spatial dimensionality.
-    /// @param rank     #rank      The rank.
     int32_t polynomial::num_coeffs_homo(int32_t num_dims, int32_t rank)
     {
         int32_t output = I2::pascal(num_dims - 1, rank);

--- a/src/csharp/Morpe/Numerics/D1/MonotonicRegressor.cs
+++ b/src/csharp/Morpe/Numerics/D1/MonotonicRegressor.cs
@@ -110,6 +110,9 @@ namespace Morpe.Numerics.D1
                         yMax: yMax);
                 }
 
+                // Throw if cancellation requested
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (type == MonotonicRegressionType.Blended)
                 {
                     // Save the non-decreasing values.  We will need them later.
@@ -124,6 +127,9 @@ namespace Morpe.Numerics.D1
                 {
                     // Update derivative and its minimum value.
                     dyMin = UpdateDerivativeAndFindMin(y: output, dy: this.derivative);
+
+                    // Throw if cancellation requested
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     // Convert a non-decreasing function to an increasing function (if necessary).
                     ConvertNonDecreasingToIncreasing(


### PR DESCRIPTION
I think it makes sense for all the comments to live in header files, so I moved all `*.cpp` function comments into the `*.h` files.